### PR TITLE
Implement emergency mode controls

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -33,6 +33,10 @@ function generatePassId() {
 }
 
 function openPass(studentID, originStaffID, destinationID, notes) {
+  // Prevent pass changes if emergency mode is enabled
+  if (getSetting('emergencyMode') === 'TRUE') {
+    throw new Error('System is in emergency mode. Passes cannot be modified');
+  }
   const sheet = getSheet(ACTIVE_PASSES_SHEET);
   const data = sheet.getDataRange().getValues();
   for (let i = 1; i < data.length; i++) {
@@ -72,6 +76,10 @@ function openPass(studentID, originStaffID, destinationID, notes) {
 }
 
 function updatePassStatus(passID, status, locationID, staffID, flag, notes) {
+  // Prevent pass changes if emergency mode is enabled
+  if (getSetting('emergencyMode') === 'TRUE') {
+    throw new Error('System is in emergency mode. Passes cannot be modified');
+  }
   const sheet = getSheet(ACTIVE_PASSES_SHEET);
   const data = sheet.getDataRange().getValues();
   let rowIndex = -1;
@@ -111,6 +119,10 @@ function updatePassStatus(passID, status, locationID, staffID, flag, notes) {
 }
 
 function closePass(passID, closingStaffID, flag, notes) {
+  // Prevent pass changes if emergency mode is enabled
+  if (getSetting('emergencyMode') === 'TRUE') {
+    throw new Error('System is in emergency mode. Passes cannot be modified');
+  }
   const sheet = getSheet(ACTIVE_PASSES_SHEET);
   const data = sheet.getDataRange().getValues();
   let rowIndex = -1;

--- a/Setup.js
+++ b/Setup.js
@@ -29,5 +29,15 @@ function toggleDevMode() {
 }
 
 function toggleEmergencyMode() {
-  SpreadsheetApp.getActiveSpreadsheet().toast('Emergency mode placeholder');
+  const current = getSetting('emergencyMode') === 'TRUE';
+  const newVal = current ? 'FALSE' : 'TRUE';
+  const ss = getSpreadsheet();
+  const settings = ss.getSheetByName('Settings');
+  const data = settings.getDataRange().getValues();
+  const row = data.findIndex(r => r[0] === 'emergencyMode') + 1;
+  if (row > 0) {
+    settings.getRange(row, 2).setValue(newVal);
+  }
+  PropertiesService.getScriptProperties().deleteProperty(CACHE_KEY_PREFIX + SHEETS.SETTINGS);
+  SpreadsheetApp.getActiveSpreadsheet().toast('Emergency mode: ' + newVal);
 }


### PR DESCRIPTION
## Summary
- disallow pass changes when `emergencyMode` is TRUE
- toggle emergency mode via admin menu with cache clearing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684073b54a2c8333a15538b7cfb6cac8