### PR TITLE
Handle restroom pass rules in updatePassStatus

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -87,6 +87,22 @@ function updatePassStatus(passID, status, locationID, staffID, flag, notes) {
     throw new Error('Pass not found');
   }
 
+  const currentDestination = String(row[4]).toUpperCase();
+  if (
+    currentDestination === 'RESTROOM' &&
+    (status === 'IN' || locationID !== row[4])
+  ) {
+    Logger.log(
+      'Invalid update attempt on restroom pass ' +
+        passID +
+        ': status=' +
+        status +
+        ', destinationID=' +
+        locationID
+    );
+    return;
+  }
+
   const legID = Number(row[5]) + 1;
   const now = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- block updates to restroom passes when trying to check IN or change destination
- log attempts at invalid restroom updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684073b698f4833383783c9d7c67fede