### PR TITLE
Enhance security and sanitize inputs

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -12,6 +12,20 @@ function getSheet(name) {
   return SpreadsheetApp.getActiveSpreadsheet().getSheetByName(name);
 }
 
+// Basic input validation helpers
+function sanitizeId(id) {
+  id = String(id || '').trim();
+  if (!/^[\w-]+$/.test(id)) {
+    throw new Error('Invalid characters in ID');
+  }
+  return id;
+}
+
+function sanitizeText(text) {
+  text = String(text || '').replace(/[<>]/g, '').trim();
+  return text;
+}
+
 function appendPassLog(entry) {
   const sheet = getSheet(PASS_LOG_SHEET);
   sheet.appendRow([
@@ -33,6 +47,10 @@ function generatePassId() {
 }
 
 function openPass(studentID, originStaffID, destinationID, notes) {
+  studentID = sanitizeId(studentID);
+  originStaffID = sanitizeId(originStaffID);
+  destinationID = sanitizeId(destinationID);
+  notes = sanitizeText(notes);
   const sheet = getSheet(ACTIVE_PASSES_SHEET);
   const data = sheet.getDataRange().getValues();
   for (let i = 1; i < data.length; i++) {
@@ -72,6 +90,12 @@ function openPass(studentID, originStaffID, destinationID, notes) {
 }
 
 function updatePassStatus(passID, status, locationID, staffID, flag, notes) {
+  passID = sanitizeId(passID);
+  status = sanitizeText(status);
+  locationID = sanitizeId(locationID);
+  staffID = sanitizeId(staffID);
+  flag = flag ? sanitizeId(flag) : '';
+  notes = sanitizeText(notes);
   const sheet = getSheet(ACTIVE_PASSES_SHEET);
   const data = sheet.getDataRange().getValues();
   let rowIndex = -1;
@@ -111,6 +135,10 @@ function updatePassStatus(passID, status, locationID, staffID, flag, notes) {
 }
 
 function closePass(passID, closingStaffID, flag, notes) {
+  passID = sanitizeId(passID);
+  closingStaffID = sanitizeId(closingStaffID);
+  flag = flag ? sanitizeId(flag) : '';
+  notes = sanitizeText(notes);
   const sheet = getSheet(ACTIVE_PASSES_SHEET);
   const data = sheet.getDataRange().getValues();
   let rowIndex = -1;

--- a/Router.js
+++ b/Router.js
@@ -20,7 +20,28 @@ function doGet(e) {
   }
 }
 
+function verifyXsrfToken(token) {
+  const stored = PropertiesService.getScriptProperties().getProperty('XSRF_TOKEN');
+  return token && token === stored;
+}
+
 function doPost(e) {
-  // Placeholder for POST actions
-  return doGet(e);
+  const params = e && e.parameter ? e.parameter : {};
+  if (!verifyXsrfToken(params.token)) {
+    return HtmlService.createHtmlOutput('Invalid or missing token');
+  }
+
+  switch (params.action) {
+    case 'openPass':
+      const passId = openPass(params.studentID, params.originStaffID, params.destinationID, params.notes);
+      return ContentService.createTextOutput(passId);
+    case 'updatePass':
+      updatePassStatus(params.passID, params.status, params.locationID, params.staffID, params.flag, params.notes);
+      return ContentService.createTextOutput('OK');
+    case 'closePass':
+      closePass(params.passID, params.closingStaffID, params.flag, params.notes);
+      return ContentService.createTextOutput('OK');
+    default:
+      return HtmlService.createHtmlOutput('Unknown action');
+  }
 }


### PR DESCRIPTION
## Summary
- add basic input sanitizers to `Code.js`
- sanitize IDs and notes before writing to sheets
- verify XSRF token in `Router.doPost` and handle pass actions

## Testing
- `node --check Router.js`
- `node --check Code.js`


------
https://chatgpt.com/codex/tasks/task_e_684073badbd88333b25672ed5a42381e