### PR TITLE
Implement automatic pass closure

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -159,3 +159,39 @@ function closePass(passID, closingStaffID, flag, notes) {
 
   sheet.deleteRow(rowIndex);
 }
+
+function autoClosePasses() {
+  const current = getCurrentPeriod();
+  const next = getNextPeriod();
+  Logger.log('Auto-closing passes. Current: ' + (current ? current.period : 'N/A') + ' Next: ' + (next ? next.period : 'N/A'));
+
+  const sheet = getSheet(ACTIVE_PASSES_SHEET);
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    const passID = row[0];
+    const status = row[7];
+    const staffID = row[3];
+
+    const staff = getStaffRecordById(staffID);
+
+    if (status === 'OUT') {
+      closePass(passID, staffID, 'autoClose', 'Period change');
+      continue;
+    }
+
+    if (!staff) {
+      closePass(passID, staffID, 'autoClose', 'Period change');
+      continue;
+    }
+
+    if (staff.type === 'support') {
+      const override = String(staff.record.periodOverride).toUpperCase() === 'TRUE';
+      if (!override) {
+        closePass(passID, staffID, 'autoClose', 'Period change');
+      }
+    } else {
+      closePass(passID, staffID, 'autoClose', 'Period change');
+    }
+  }
+}

--- a/Data.js
+++ b/Data.js
@@ -10,7 +10,8 @@ const SHEETS = {
   TEACHERS: 'Teacher Data',
   SUPPORT: 'Support Data',
   ADMINS: 'Admin Data',
-  SETTINGS: 'Settings'
+  SETTINGS: 'Settings',
+  BELL_SCHEDULE: 'Bell Schedule'
 };
 
 function getSpreadsheet() {
@@ -71,16 +72,71 @@ function getTeacherByEmail(email) {
   return findByEmail(SHEETS.TEACHERS, email);
 }
 
+function getTeacherById(id) {
+  const data = getData(SHEETS.TEACHERS);
+  return data.find(r => String(r.staffID) === String(id));
+}
+
 function getSupportByEmail(email) {
   return findByEmail(SHEETS.SUPPORT, email);
+}
+
+function getSupportById(id) {
+  const data = getData(SHEETS.SUPPORT);
+  return data.find(r => String(r.staffID) === String(id));
 }
 
 function getAdminByEmail(email) {
   return findByEmail(SHEETS.ADMINS, email);
 }
 
+function getAdminById(id) {
+  const data = getData(SHEETS.ADMINS);
+  return data.find(r => String(r.staffID) === String(id));
+}
+
+function getStaffRecordById(id) {
+  const teacher = getTeacherById(id);
+  if (teacher) return { type: 'teacher', record: teacher };
+  const support = getSupportById(id);
+  if (support) return { type: 'support', record: support };
+  const admin = getAdminById(id);
+  if (admin) return { type: 'admin', record: admin };
+  return null;
+}
+
 function getSetting(key) {
   const data = getData(SHEETS.SETTINGS);
   const entry = data.find(r => r.settingKey === key);
   return entry ? entry.settingValue : null;
+}
+
+function getBellSchedule() {
+  return getData(SHEETS.BELL_SCHEDULE);
+}
+
+function getCurrentPeriod() {
+  const tz = getSetting('systemTimezone') || Session.getScriptTimeZone();
+  const dayType = getSetting('dayType');
+  const schedule = getBellSchedule().filter(p => !dayType || p.dayType === dayType);
+  const nowStr = Utilities.formatDate(new Date(), tz, 'HH:mm');
+  for (let i = 0; i < schedule.length; i++) {
+    if (nowStr >= schedule[i].startTime && nowStr < schedule[i].endTime) {
+      return schedule[i];
+    }
+  }
+  return null;
+}
+
+function getNextPeriod() {
+  const tz = getSetting('systemTimezone') || Session.getScriptTimeZone();
+  const dayType = getSetting('dayType');
+  const schedule = getBellSchedule().filter(p => !dayType || p.dayType === dayType);
+  const nowStr = Utilities.formatDate(new Date(), tz, 'HH:mm');
+  for (let i = 0; i < schedule.length; i++) {
+    if (nowStr < schedule[i].startTime) {
+      return schedule[i];
+    }
+  }
+  return null;
 }

--- a/Setup.js
+++ b/Setup.js
@@ -12,6 +12,7 @@ function onOpen() {
 
 function setupSystem() {
   SpreadsheetApp.getActiveSpreadsheet().toast('Setup placeholder');
+  installAutoCloseTriggers();
 }
 
 function toggleDevMode() {
@@ -30,4 +31,24 @@ function toggleDevMode() {
 
 function toggleEmergencyMode() {
   SpreadsheetApp.getActiveSpreadsheet().toast('Emergency mode placeholder');
+}
+
+function installAutoCloseTriggers() {
+  const tz = getSetting('systemTimezone') || Session.getScriptTimeZone();
+  const dayType = getSetting('dayType');
+  const schedule = getBellSchedule().filter(p => !dayType || p.dayType === dayType);
+
+  const triggers = ScriptApp.getProjectTriggers();
+  triggers.forEach(t => {
+    if (t.getHandlerFunction() === 'autoClosePasses') {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+
+  const today = new Date();
+  schedule.forEach(p => {
+    const [h, m] = String(p.endTime).split(':').map(Number);
+    const d = new Date(today.getFullYear(), today.getMonth(), today.getDate(), h, m, 0);
+    ScriptApp.newTrigger('autoClosePasses').timeBased().at(d).create();
+  });
 }


### PR DESCRIPTION
## Summary
- add `BELL_SCHEDULE` constant and schedule helpers
- expose staff lookup helpers for `autoClosePasses`
- implement `autoClosePasses` to close passes at period changes
- install triggers during setup to run the auto close logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684073b951ec8333a92555e6e452125f