### PR TITLE
[EagleHallPass] Implement support dashboard features

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -57,6 +57,27 @@ function getCurrentStudentPass(studentID) {
   return null;
 }
 
+function getAllActivePasses() {
+  const sheet = getSheet(ACTIVE_PASSES_SHEET);
+  const data = sheet.getDataRange().getValues();
+  const passes = [];
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    passes.push({
+      passID: row[0],
+      studentID: row[1],
+      originStaffID: row[2],
+      staffID: row[3],
+      destinationID: row[4],
+      legID: row[5],
+      state: row[6],
+      status: row[7],
+      startTime: row[8]
+    });
+  }
+  return passes;
+}
+
 function openPass(studentID, originStaffID, destinationID, notes) {
   // Prevent pass changes if emergency mode is enabled
   if (getSetting('emergencyMode') === 'TRUE') {

--- a/SupportUI.js
+++ b/SupportUI.js
@@ -8,3 +8,12 @@ function renderSupportDashboard(support) {
   template.support = support;
   return template.evaluate().setTitle('Eagle Hall Pass - Support');
 }
+
+function listActivePasses() {
+  return getAllActivePasses();
+}
+
+function supportAction(data) {
+  const res = doPost({ postData: { contents: JSON.stringify(data) } });
+  return res.getContent();
+}

--- a/support.html
+++ b/support.html
@@ -7,5 +7,74 @@
   <body>
     <h1>Support Dashboard</h1>
     <p>Welcome, <?= support.firstName ?> <?= support.lastName ?>.</p>
+    <button onclick="openPass()">Open Pass</button>
+
+    <table id="active-passes" border="1">
+      <thead>
+        <tr>
+          <th>Student ID</th>
+          <th>Status</th>
+          <th>Destination</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody id="pass-body"></tbody>
+    </table>
+
+    <script>
+      function renderPasses(passes) {
+        var body = document.getElementById('pass-body');
+        body.innerHTML = '';
+        passes.forEach(function(p) {
+          var tr = document.createElement('tr');
+          var btn =
+            '<button onclick="closePass(\'' + p.passID + '\')">Close</button>';
+          tr.innerHTML =
+            '<td>' +
+            p.studentID +
+            '</td><td>' +
+            p.status +
+            '</td><td>' +
+            p.destinationID +
+            '</td><td>' +
+            btn +
+            '</td>';
+          body.appendChild(tr);
+        });
+      }
+
+      function fetchPasses() {
+        google.script.run.withSuccessHandler(renderPasses).listActivePasses();
+      }
+
+      function openPass() {
+        var studentID = prompt('Student ID');
+        if (!studentID) return;
+        var destinationID = prompt('Destination ID');
+        if (!destinationID) return;
+        google.script.run
+          .withSuccessHandler(fetchPasses)
+          .supportAction({
+            action: 'openPass',
+            studentID: studentID,
+            destinationID: destinationID,
+            notes: ''
+          });
+      }
+
+      function closePass(passID) {
+        google.script.run
+          .withSuccessHandler(fetchPasses)
+          .supportAction({
+            action: 'closePass',
+            passID: passID,
+            flag: '',
+            notes: ''
+          });
+      }
+
+      fetchPasses();
+      setInterval(fetchPasses, 60000);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `getAllActivePasses` on server
- allow Support to fetch active passes and post actions
- show all active passes in Support dashboard
- enable Support to open or close passes from dashboard

## Testing
- `git status --short`
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_68407f27ef8c8333b4f7b2b71dbb34bc