### PR TITLE
[EagleHallPass] Add CSRF token support

### DIFF
--- a/AdminUI.js
+++ b/AdminUI.js
@@ -6,5 +6,6 @@ function renderAdminDashboard(admin) {
   }
   const template = HtmlService.createTemplateFromFile('admin');
   template.admin = admin;
+  template.csrfToken = getOrCreateCsrfToken();
   return template.evaluate().setTitle('Eagle Hall Pass - Admin');
 }

--- a/Auth.js
+++ b/Auth.js
@@ -28,3 +28,13 @@ function getEffectiveUser(email) {
   }
   return getUserRecord(email);
 }
+
+function getOrCreateCsrfToken() {
+  const props = PropertiesService.getUserProperties();
+  let token = props.getProperty('csrfToken');
+  if (!token) {
+    token = Utilities.getUuid();
+    props.setProperty('csrfToken', token);
+  }
+  return token;
+}

--- a/Router.js
+++ b/Router.js
@@ -28,6 +28,10 @@ function doPost(e) {
   }
   const data = JSON.parse(e.postData.contents || '{}');
   const action = data.action;
+  const token = data.csrfToken;
+  if (token !== getOrCreateCsrfToken()) {
+    return ContentService.createTextOutput('ERROR: Invalid CSRF token');
+  }
 
   try {
     switch (action) {

--- a/StudentUI.js
+++ b/StudentUI.js
@@ -6,5 +6,6 @@ function renderStudentDashboard(student) {
   }
   const template = HtmlService.createTemplateFromFile('student');
   template.student = student;
+  template.csrfToken = getOrCreateCsrfToken();
   return template.evaluate().setTitle('Eagle Hall Pass - Student');
 }

--- a/SupportUI.js
+++ b/SupportUI.js
@@ -6,6 +6,7 @@ function renderSupportDashboard(support) {
   }
   const template = HtmlService.createTemplateFromFile('support');
   template.support = support;
+  template.csrfToken = getOrCreateCsrfToken();
   return template.evaluate().setTitle('Eagle Hall Pass - Support');
 }
 

--- a/TeacherUI.js
+++ b/TeacherUI.js
@@ -6,5 +6,6 @@ function renderTeacherDashboard(teacher) {
   }
   const template = HtmlService.createTemplateFromFile('teacher');
   template.teacher = teacher;
+  template.csrfToken = getOrCreateCsrfToken();
   return template.evaluate().setTitle('Eagle Hall Pass - Teacher');
 }

--- a/admin.html
+++ b/admin.html
@@ -16,6 +16,7 @@
     </div>
 
     <script>
+      const CSRF_TOKEN = '<?= csrfToken ?>';
       function updateEmergencyStatus(isOn) {
         var text = document.getElementById('emergency-status-text');
         text.textContent = isOn ? 'ON' : 'OFF';

--- a/student.html
+++ b/student.html
@@ -10,6 +10,7 @@
     <div id="pass-state">Current Pass: <span id="pass-state-text">Loading...</span></div>
 
     <script>
+      const CSRF_TOKEN = '<?= csrfToken ?>';
       function updatePassState(pass) {
         var text = document.getElementById('pass-state-text');
         if (!pass) {

--- a/support.html
+++ b/support.html
@@ -22,6 +22,7 @@
     </table>
 
     <script>
+      const CSRF_TOKEN = '<?= csrfToken ?>';
       function renderPasses(passes) {
         var body = document.getElementById('pass-body');
         body.innerHTML = '';
@@ -58,7 +59,8 @@
             action: 'openPass',
             studentID: studentID,
             destinationID: destinationID,
-            notes: ''
+            notes: '',
+            csrfToken: CSRF_TOKEN
           });
       }
 
@@ -69,7 +71,8 @@
             action: 'closePass',
             passID: passID,
             flag: '',
-            notes: ''
+            notes: '',
+            csrfToken: CSRF_TOKEN
           });
       }
 

--- a/teacher.html
+++ b/teacher.html
@@ -25,6 +25,7 @@
     </table>
 
     <script>
+      const CSRF_TOKEN = '<?= csrfToken ?>';
       function renderStudents(list) {
         var tbody = document.getElementById('student-table').querySelector('tbody');
         tbody.innerHTML = '';
@@ -42,7 +43,8 @@
               action: 'openPass',
               studentID: s.studentID,
               destinationID: dest,
-              notes: ''
+              notes: '',
+              csrfToken: CSRF_TOKEN
             };
             google.script.run.withSuccessHandler(fetchActivePasses)
               .doPost({ postData: { contents: JSON.stringify(body) } });
@@ -69,7 +71,7 @@
           var closeBtn = document.createElement('button');
           closeBtn.textContent = 'Close Pass';
           closeBtn.onclick = function() {
-            var body = { action: 'closePass', passID: p.passID };
+            var body = { action: 'closePass', passID: p.passID, csrfToken: CSRF_TOKEN };
             google.script.run.withSuccessHandler(fetchActivePasses)
               .doPost({ postData: { contents: JSON.stringify(body) } });
           };


### PR DESCRIPTION
## Summary
- generate per-user CSRF token using `getOrCreateCsrfToken`
- attach token to dashboard templates
- expose token to client pages
- include token in POST requests and validate in `doPost`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840835d6a9c8333aa2e52ca4f61e9a4