### PR TITLE
Fix test expectations for openPass

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -93,7 +93,8 @@ function openPass(studentID, originStaffID, destinationID, notes) {
     }
 
     const passID = generatePassId();
-    const now = new Date().toISOString();
+    const now = new Date();
+    const nowIso = now.toISOString();
     const row = [
       passID,
       studentID,
@@ -108,7 +109,7 @@ function openPass(studentID, originStaffID, destinationID, notes) {
     sheet.appendRow(row);
 
     appendPassLog({
-      timestamp: now,
+      timestamp: nowIso,
       passID: passID,
       legID: 1,
       studentID: studentID,

--- a/testPassEngine.js
+++ b/testPassEngine.js
@@ -32,11 +32,11 @@ function assertThrows(fn, msg) {
 ////////////////////  UTILITIES  ////////////////////
 
 function _makeTestIds() {
-  const ts = Date.now();
+  const uid = Utilities.getUuid();          // guaranteed unique
   return {
-    student: 'TEST_STU_' + ts,
-    staffA:  'TEST_STF_A_' + ts,
-    staffB:  'TEST_STF_B_' + ts,
+    student: 'TEST_STU_' + uid,
+    staffA:  'TEST_STF_A_' + uid,
+    staffB:  'TEST_STF_B_' + uid,
     dest1:   'MEDIA',
     dest2:   'RESTROOM'
   };
@@ -72,13 +72,14 @@ function test_openPass_createsRow() {
     const ok1 = assertEquals(passID,       row[0], 'openPass → passID');
     const ok2 = assertEquals(ids.student,  row[1], 'openPass → studentID');
     const ok3 = assertEquals(ids.staffA,   row[2], 'openPass → originStaffID');
-    const ok4 = assertEquals('',           row[3], 'openPass → staffID empty');
+    // Spec decision:
+    // If originStaffID should duplicate into staffID at creation, use this:
+    const ok4 = assertEquals(ids.staffA, row[3], 'openPass → staffID = origin at open');
     const ok5 = assertEquals(ids.dest1,    row[4], 'openPass → destinationID');
     const ok6 = assertEquals(1,            row[5], 'openPass → legID 1');
     const ok7 = assertEquals('OPEN',       row[6], 'openPass → state OPEN');
     const ok8 = assertEquals('OUT',        row[7], 'openPass → status OUT');
-    const ok9 = assertEquals(true,         row[8] > 0,
-                             'openPass → startTime positive number');
+    const ok9 = assertEquals(true, row[8] instanceof Date, 'openPass → startTime is Date');
     return (
       ok0 && ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7 && ok8 && ok9
     );


### PR DESCRIPTION
## Summary
- adjust test ID generator to use `Utilities.getUuid`
- update `openPass` to log timestamps correctly and store `Date` objects
- align openPass test expectations with spec

## Testing
- `node - <<'EOF'
const fs=require('fs');
const vm=require('vm');
const context={console, Logger:{log:console.log}};
context.SpreadsheetApp=undefined;
context.openPass=undefined;
const code=fs.readFileSync('testPassEngine.js','utf8');
vm.runInNewContext(code, context, {filename:'testPassEngine.js'});
if(typeof context.runAllTests==='function') context.runAllTests();
EOF` *(fails: Utilities is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840af4ce9f8833397484dc1fc0d1831