### PR TITLE
Add PWA manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Eagle Hall Pass",
+  "short_name": "Hall Pass",
+  "icons": [
+    {
+      "src": "https://via.placeholder.com/192x192.png?text=EHP",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://via.placeholder.com/512x512.png?text=EHP",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#00274C",
+  "background_color": "#FFFFFF"
+}


### PR DESCRIPTION
## Summary
- provide minimal PWA manifest with theme colors and icons

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6841938e746483339c2ddecf76f725a5